### PR TITLE
[breaking change] improve the select/3 API for key ranges

### DIFF
--- a/lib/cubdb.ex
+++ b/lib/cubdb.ex
@@ -246,25 +246,23 @@ defmodule CubDB do
       # Select all entries where "a" <= key <= "d"
       CubDB.select(db, min_key: "b", max_key: "d")
 
-  The range boundaries can be excluded by setting `min_key` or `max_key` to
-  `{key, :excluded}`:
+  The range boundaries can be excluded by setting `min_key_inclusive` or
+  `max_key_inclusive` to `false`:
 
       # Select all entries where "a" <= key < "d"
-      CubDB.select(db, min_key: "b", max_key: {"d", :excluded})
+      CubDB.select(db, min_key: "b", max_key: "d", max_key_inclusive: false)
 
-  Any of `:min_key` and `:max_key` can be omitted or set to `nil`, to leave the
-  range open-ended.
+  Any of `:min_key` and `:max_key` can be omitted, to leave the range
+  open-ended.
 
       # Select entries where key <= "a"
       CubDB.select(db, max_key: "a")
 
-      # Or, equivalently:
-      CubDB.select(db, min_key: nil, max_key: "a")
-
-  In case the key boundary is the literal value `nil`, the longer form must be used:
+  As `nil` is a valid key, setting `min_key` or `max_key` to `nil` does NOT
+  leave the range open ended:
 
       # Select entries where nil <= key <= "a"
-      CubDB.select(db, min_key: {nil, :included}, max_key: "a")
+      CubDB.select(db, min_key: nil, max_key: "a")
 
   The `reverse` option, when set to true, causes the entries to be selected and
   traversed in reverse order.
@@ -304,9 +302,10 @@ defmodule CubDB do
       {:ok, entries} = CubDB.select(db, min_key: :a, max_key: :c)
 
   If we want to get all entries with keys between `:a` and `:c`, with `:c`
-  exluded, we can do:
+  excluded, we can do:
 
-      {:ok, entries} = CubDB.select(db, min_key: :a, max_key: {:c, :excluded})
+      {:ok, entries} = CubDB.select(db,
+        min_key: :a, max_key: :c, max_key_inclusive: false)
 
   To select the last 3 entries, we can do:
 

--- a/lib/cubdb/btree.ex
+++ b/lib/cubdb/btree.ex
@@ -190,26 +190,12 @@ defmodule CubDB.Btree do
     tree
   end
 
-  @spec key_range(Btree.t(), key | Btree.KeyRange.bound(), key | Btree.KeyRange.bound(), boolean) ::
+  @spec key_range(Btree.t(), Btree.KeyRange.bound(), Btree.KeyRange.bound(), boolean) ::
           Btree.KeyRange.t()
 
   # `key_range/4` returns a `Btree.KeyRange` `Enumerable` that can be used to
   # iterate through a range of entries with key between `min_key` and `max_key`.
   def key_range(tree, min_key \\ nil, max_key \\ nil, reverse \\ false) do
-    min_key =
-      case min_key do
-        {_, x} when x == :included or x == :excluded -> min_key
-        nil -> nil
-        _ -> {min_key, :included}
-      end
-
-    max_key =
-      case max_key do
-        {_, x} when x == :included or x == :excluded -> max_key
-        nil -> nil
-        _ -> {max_key, :included}
-      end
-
     Btree.KeyRange.new(tree, min_key, max_key, reverse)
   end
 

--- a/lib/cubdb/reader.ex
+++ b/lib/cubdb/reader.ex
@@ -64,18 +64,24 @@ defmodule CubDB.Reader do
   @spec select(Btree.t(), Keyword.t()) :: any
 
   defp select(btree, options) when is_list(options) do
-    min_key = case Keyword.fetch(options, :min_key) do
-      {:ok, key} ->
-        {key, Keyword.get(options, :min_key_inclusive, true)}
-      :error ->
-        nil
-    end
-    max_key = case Keyword.fetch(options, :max_key) do
-      {:ok, key} ->
-        {key, Keyword.get(options, :max_key_inclusive, true)}
-      :error ->
-        nil
-    end
+    min_key =
+      case Keyword.fetch(options, :min_key) do
+        {:ok, key} ->
+          {key, Keyword.get(options, :min_key_inclusive, true)}
+
+        :error ->
+          nil
+      end
+
+    max_key =
+      case Keyword.fetch(options, :max_key) do
+        {:ok, key} ->
+          {key, Keyword.get(options, :max_key_inclusive, true)}
+
+        :error ->
+          nil
+      end
+
     pipe = Keyword.get(options, :pipe, [])
     reduce = Keyword.get(options, :reduce)
     reverse = Keyword.get(options, :reverse, false)

--- a/lib/cubdb/reader.ex
+++ b/lib/cubdb/reader.ex
@@ -64,8 +64,18 @@ defmodule CubDB.Reader do
   @spec select(Btree.t(), Keyword.t()) :: any
 
   defp select(btree, options) when is_list(options) do
-    min_key = Keyword.get(options, :min_key)
-    max_key = Keyword.get(options, :max_key)
+    min_key = case Keyword.fetch(options, :min_key) do
+      {:ok, key} ->
+        {key, Keyword.get(options, :min_key_inclusive, true)}
+      :error ->
+        nil
+    end
+    max_key = case Keyword.fetch(options, :max_key) do
+      {:ok, key} ->
+        {key, Keyword.get(options, :max_key_inclusive, true)}
+      :error ->
+        nil
+    end
     pipe = Keyword.get(options, :pipe, [])
     reduce = Keyword.get(options, :reduce)
     reverse = Keyword.get(options, :reverse, false)

--- a/test/cubdb/btree_test.exs
+++ b/test/cubdb/btree_test.exs
@@ -381,24 +381,24 @@ defmodule CubDB.BtreeTest do
 
     assert %Btree.KeyRange{
              btree: ^btree,
-             min_key: {^min_key, :included},
-             max_key: {^max_key, :included},
+             min_key: {^min_key, true},
+             max_key: {^max_key, true},
              reverse: ^reverse
-           } = Btree.key_range(btree, min_key, max_key, reverse)
+           } = Btree.key_range(btree, {min_key, true}, {max_key, true}, reverse)
 
     assert %Btree.KeyRange{
              btree: ^btree,
              min_key: nil,
-             max_key: {^max_key, :excluded},
+             max_key: {^max_key, false},
              reverse: ^reverse
-           } = Btree.key_range(btree, nil, {max_key, :excluded}, reverse)
+           } = Btree.key_range(btree, nil, {max_key, false}, reverse)
 
     assert %Btree.KeyRange{
              btree: ^btree,
-             min_key: {^min_key, :excluded},
+             min_key: {^min_key, false},
              max_key: nil,
              reverse: false
-           } = Btree.key_range(btree, {min_key, :excluded}, nil)
+           } = Btree.key_range(btree, {min_key, false}, nil)
   end
 
   test "dirt_factor/1 returns a numeric dirt factor" do

--- a/test/cubdb_test.exs
+++ b/test/cubdb_test.exs
@@ -74,7 +74,8 @@ defmodule CubDBTest do
     assert {:ok, result} =
              CubDB.select(db,
                min_key: {:names, 0},
-               max_key: {{:names, 2}, :excluded}
+               max_key: {:names, 2},
+               max_key_inclusive: false
              )
 
     assert result == [{{:names, 0}, "Ada"}, {{:names, 1}, "Jay"}]

--- a/test/property_based/cubdb/btree/key_range_test.exs
+++ b/test/property_based/cubdb/btree/key_range_test.exs
@@ -30,10 +30,8 @@ defmodule PropertyBased.Btree.KeyRangeTest do
           repeat_for: 50 do
       store = Store.TestStore.new()
       btree = make_btree(store, key_values, cap)
-      min_incl = if min_included, do: :included, else: :excluded
-      max_incl = if max_included, do: :included, else: :excluded
-      min_key = {min, min_incl}
-      max_key = {max, max_incl}
+      min_key = {min, min_included}
+      max_key = {max, max_included}
       key_range = KeyRange.new(btree, min_key, max_key)
       reverse_key_range = KeyRange.new(btree, min_key, max_key, true)
 


### PR DESCRIPTION
The previous API had a few shortcomings:

  - Corner cases for `nil` min_key/max_key and `min_key`/`max_key` literally being tuples like `{123, :included}`

  - Misspelling `:included` or `:excluded` would silently fail or lead to unexpected results

  - The API was a bit cumbersome in general

See also the discussion here: https://github.com/lucaong/cubdb/issues/3

The new API is much clearer, and removes the shortcomings:

```elixir
# Exclusive ranges:
## Before:
{:ok, result} = CubDB.select(db,
  min_key: :foo,
  max_key: {:bar, :excluded}
)
## Now:
{:ok, result} = CubDB.select(db,
  min_key: :foo,
  max_key: :bar,
  max_key_inclusive: false
)

# Open-ended ranges:
## Before
{:ok, result} = CubDB.select(db,
  min_key: :foo,
  max_key: nil
)
## Now
{:ok, result} = CubDB.select(db,
  min_key: :foo
)

# Setting min/max key to `nil`:
## Before:
{:ok, result} = CubDB.select(db,
  min_key: {nil, :included},
  max_key: :bar
)
# Now:
{:ok, result} = CubDB.select(db,
  min_key: nil,
  max_key: :bar
)
```