### PR TITLE
Improve get_multi interface (breaking change)

### DIFF
--- a/lib/cubdb.ex
+++ b/lib/cubdb.ex
@@ -537,19 +537,18 @@ defmodule CubDB do
     GenServer.call(db, {:get_and_update_multi, keys_to_get, fun}, timeout)
   end
 
-  @spec get_multi(GenServer.server(), [key], value) :: [value]
+  @spec get_multi(GenServer.server(), [key]) :: %{key => value}
 
   @doc """
   Gets multiple entries corresponding by the given keys all at once, atomically.
 
-  The keys to get are passed as a list. The result is a list of values
-  corresponding to the given keys, or `default` for keys that are not present in
-  the database.
+  The keys to get are passed as a list. The result is a map of keys to values
+  corresponding to the given keys. Keys that are not present in
+  the database won't be in the result map.
   """
-  def get_multi(db, keys, default \\ nil) do
+  def get_multi(db, keys) do
     fun = fn entries ->
-      values = keys |> Enum.map(fn key -> Map.get(entries, key, default) end)
-      {values, %{}, []}
+      {entries, %{}, []}
     end
 
     {:ok, result} = GenServer.call(db, {:get_and_update_multi, keys, fun})

--- a/test/cubdb_test.exs
+++ b/test/cubdb_test.exs
@@ -243,19 +243,17 @@ defmodule CubDBTest do
   test "get_multi/3, put_multi/2 and delete_multi/2 work as expected", %{tmp_dir: tmp_dir} do
     {:ok, db} = CubDB.start_link(tmp_dir)
 
-    entries = [a: 1, b: 2, c: 3, d: 4]
-    keys = Keyword.keys(entries)
-    values = Keyword.values(entries)
+    entries = %{a: 1, b: 2, c: 3, d: 4}
+    keys = Map.keys(entries)
 
     assert :ok = CubDB.put_multi(db, entries)
-    assert CubDB.size(db) == length(entries)
+    assert CubDB.size(db) == length(Map.to_list(entries))
 
-    assert ^values = CubDB.get_multi(db, keys)
-    assert [3, 2, nil] = CubDB.get_multi(db, [:c, :b, :x])
-    assert [3, 2, :not_found] = CubDB.get_multi(db, [:c, :b, :x], :not_found)
+    assert entries == CubDB.get_multi(db, keys)
+    assert %{c: 3, b: 2} == CubDB.get_multi(db, [:c, :b, :x])
 
     assert :ok = CubDB.delete_multi(db, keys)
-    assert [nil, nil, nil, nil] = CubDB.get_multi(db, keys)
+    assert %{} == CubDB.get_multi(db, keys)
     assert CubDB.size(db) == 0
   end
 


### PR DESCRIPTION
Before, get_multi/3 was returning a list of value corresponding to the
given keys, or the default value when the key was not in the database.

This API had a number of drawbacks, like the difficulty to distinguish
between a missing key from a key associated to the default value, or the
inconvenience of matching keys to values. Also, it is not consistent
with the argument of the function passed to get_and_update_multi.

The new version solves these problems (at the cost of breaking backward
compatibility) by returning a map of keys to values fro the selected
keys. When a key is not present in the database, it is omitted from the
result map.

Example:

```elixir
CubDB.put_multi(db, a: 1, b: 2, c: nil)

# Before:
CubDB.get_multi(db, [:a, :b, :c, :x])
# => [1, 2, nil, nil]

# Now:
CubDB.get_multi(db, [:a, :b, :c, :x])
# => %{a: 1, b: 2, c: nil}
```