### PR TITLE
Do not crash main CubDB process if Compactor crashes

### DIFF
--- a/test/cubdb/compactor_test.exs
+++ b/test/cubdb/compactor_test.exs
@@ -30,7 +30,10 @@ defmodule CubDB.Store.CompactorTest do
 
     {:ok, store} = Store.File.create(Path.join(tmp_dir, "1.compact"))
 
-    {:ok, _pid} = Compactor.start_link(self(), btree, store)
+    {:ok, pid} = Compactor.start_link(self(), btree, store)
+
+    {:links, links} = Process.info(self(), :links)
+    assert Enum.member?(links, pid) == true
 
     assert_receive {:compaction_completed, ^btree, compacted_btree}, 1000
     assert compacted_btree.size == btree.size


### PR DESCRIPTION
This commits prevents crashes of the main CubDB process should the
compaction task crash. It also refactors the compaction code, making it
simpler to follow.

Compaction is performed on the side, often auto-triggered, to optimize
file utilization. Compaction crashes do not cause problems, and CubDB
cleanly handles failed compactions. Therefore, it makes sense to avoid
crashing the main process in case the compaction process crashes.