### PR TITLE
change default to auto_file_sync: true

### DIFF
--- a/benchmarks/get.exs
+++ b/benchmarks/get.exs
@@ -27,7 +27,7 @@ Benchee.run(
   },
   before_scenario: fn input ->
     cleanup.()
-    {:ok, db} = CubDB.start_link(data_dir)
+    {:ok, db} = CubDB.start_link(data_dir, auto_file_sync: false)
     for key <- (0..n), do: CubDB.put(db, key, input)
     db
   end,

--- a/lib/cubdb.ex
+++ b/lib/cubdb.ex
@@ -188,7 +188,7 @@ defmodule CubDB do
       clean_up_pending: false,
       readers: %{},
       auto_compact: false,
-      auto_file_sync: false,
+      auto_file_sync: true,
       subs: []
     ]
   end
@@ -212,8 +212,9 @@ defmodule CubDB do
     to `false`. See `set_auto_compact/2` for the possible values
 
     - `auto_file_sync`: whether to force flush the disk buffer on each write. It
-    defaults to `false`. If set to `true`, write performance is slower, but
-    durability is strictly guaranteed. See `set_auto_file_sync/2` for details.
+    defaults to `true`. If set to `false`, write performance is faster, but
+    durability of writes is not strictly guaranteed. See `set_auto_file_sync/2`
+    for details.
 
   `GenServer` options like `name` and `timeout` can also be given, and are
   forwarded to `GenServer.start_link/3` as the third argument.
@@ -802,7 +803,7 @@ defmodule CubDB do
   @doc false
   def init([data_dir, options]) do
     auto_compact = parse_auto_compact!(Keyword.get(options, :auto_compact, false))
-    auto_file_sync = Keyword.get(options, :auto_file_sync, false)
+    auto_file_sync = Keyword.get(options, :auto_file_sync, true)
 
     with file_name when is_binary(file_name) or is_nil(file_name) <- find_db_file(data_dir),
          {:ok, store} <-

--- a/test/cubdb_test.exs
+++ b/test/cubdb_test.exs
@@ -554,18 +554,24 @@ defmodule CubDBTest do
     assert Process.alive?(db)
   end
 
-  test "set_auto_file_sync/1 configures auto file sync behavior", %{tmp_dir: tmp_dir} do
-    {:ok, db} = CubDB.start_link(tmp_dir, auto_file_sync: true)
+  test "auto_file_sync is true by default", %{tmp_dir: tmp_dir} do
+    {:ok, db} = CubDB.start_link(tmp_dir)
 
     assert %CubDB.State{auto_file_sync: true} = :sys.get_state(db)
+  end
 
-    CubDB.set_auto_file_sync(db, false)
+  test "set_auto_file_sync/1 configures auto file sync behavior", %{tmp_dir: tmp_dir} do
+    {:ok, db} = CubDB.start_link(tmp_dir, auto_file_sync: false)
 
     assert %CubDB.State{auto_file_sync: false} = :sys.get_state(db)
 
     CubDB.set_auto_file_sync(db, true)
 
     assert %CubDB.State{auto_file_sync: true} = :sys.get_state(db)
+
+    CubDB.set_auto_file_sync(db, false)
+
+    assert %CubDB.State{auto_file_sync: false} = :sys.get_state(db)
   end
 
   test "file_sync/1 returns :ok", %{tmp_dir: tmp_dir} do


### PR DESCRIPTION
This uses the safer (but slower on writes) option by default, and
require the user to manually decide when they prefer write performance
over strict durability of writes.