### PR TITLE
Better handling of Compactor and CatchUp tasks

### DIFF
--- a/lib/cubdb/catch_up.ex
+++ b/lib/cubdb/catch_up.ex
@@ -19,12 +19,6 @@ defmodule CubDB.CatchUp do
   @value Btree.__value__()
   @deleted Btree.__deleted__()
 
-  @spec start_link(pid, Btree.t(), Btree.t(), Btree.t()) :: {:ok, pid}
-
-  def start_link(caller, compacted_btree, original_btree, latest_btree) do
-    Task.start_link(__MODULE__, :run, [caller, compacted_btree, original_btree, latest_btree])
-  end
-
   @spec run(pid, Btree.t(), Btree.t(), Btree.t()) :: :ok
 
   def run(caller, compacted_btree, original_btree, latest_btree) do

--- a/lib/cubdb/compactor.ex
+++ b/lib/cubdb/compactor.ex
@@ -18,12 +18,6 @@ defmodule CubDB.Compactor do
   alias CubDB.Btree
   alias CubDB.Store
 
-  @spec start_link(pid, Btree.t(), Store.File.t()) :: {:ok, pid}
-
-  def start_link(caller, btree, store) do
-    Task.start_link(__MODULE__, :run, [caller, btree, store])
-  end
-
   @spec run(pid, Btree.t(), Store.File.t()) :: :ok
 
   def run(caller, btree, store) do

--- a/test/cubdb/catch_up_test.exs
+++ b/test/cubdb/catch_up_test.exs
@@ -5,7 +5,7 @@ defmodule CubDB.Store.CatchUpTest do
   alias CubDB.Store
   alias CubDB.CatchUp
 
-  test "start_link/4 catches up the compacted tree with the diff updates and reports result" do
+  test "run/4 catches up the compacted tree with the diff updates and reports result" do
     {:ok, store} = Store.TestStore.create()
 
     entries = [foo: 1, bar: 2]
@@ -25,7 +25,7 @@ defmodule CubDB.Store.CatchUpTest do
     {:ok, compacted_store} = Store.TestStore.create()
     compacted_btree = Btree.load(original_btree, compacted_store)
 
-    {:ok, _pid} = CatchUp.start_link(self(), compacted_btree, original_btree, latest_btree)
+    CatchUp.run(self(), compacted_btree, original_btree, latest_btree)
 
     assert_receive {:catch_up, catched_up_btree, ^latest_btree}
     assert Enum.to_list(catched_up_btree) == Enum.to_list(latest_btree)

--- a/test/cubdb/compactor_test.exs
+++ b/test/cubdb/compactor_test.exs
@@ -19,7 +19,7 @@ defmodule CubDB.Store.CompactorTest do
     {:ok, tmp_dir: tmp_dir}
   end
 
-  test "start_link/3 runs compaction on a Btree and sends back the result", %{tmp_dir: tmp_dir} do
+  test "run/3 runs compaction on a Btree and sends back the result", %{tmp_dir: tmp_dir} do
     entries = [foo: 1, bar: 2, baz: 3]
     {:ok, store} = Store.TestStore.create()
 
@@ -30,10 +30,7 @@ defmodule CubDB.Store.CompactorTest do
 
     {:ok, store} = Store.File.create(Path.join(tmp_dir, "1.compact"))
 
-    {:ok, pid} = Compactor.start_link(self(), btree, store)
-
-    {:links, links} = Process.info(self(), :links)
-    assert Enum.member?(links, pid) == true
+    Compactor.run(self(), btree, store)
 
     assert_receive {:compaction_completed, ^btree, compacted_btree}, 1000
     assert compacted_btree.size == btree.size


### PR DESCRIPTION
Avoiding the use of `:trap_exit` and using a `Task.Supervisor` instead.
The logic still ensures that if one of those tasks crashes, the main
`CubDB` process does not crash, but still cleans up resources.