### PR TITLE
CubDB.put_new/3

### DIFF
--- a/test/cubdb_test.exs
+++ b/test/cubdb_test.exs
@@ -111,7 +111,7 @@ defmodule CubDBTest do
     assert Process.alive?(pid)
   end
 
-  test "put/3, get/3, fetch/2, delete/3, and has_key?/2 work as expected", %{tmp_dir: tmp_dir} do
+  test "put/3, get/3, fetch/2, delete/3, has_key?/2, and put_new/3 work as expected", %{tmp_dir: tmp_dir} do
     {:ok, db} = CubDB.start_link(tmp_dir)
     key = {:some, arbitrary: "key"}
 
@@ -130,6 +130,14 @@ defmodule CubDBTest do
     assert CubDB.get(db, key) == nil
     assert :error = CubDB.fetch(db, key)
     assert CubDB.has_key?(db, key) == false
+
+    assert :ok = CubDB.put_new(db, key, 123)
+    assert :exists = CubDB.put_new(db, key, 321)
+    assert CubDB.get(db, key) == 123
+
+    CubDB.stop(db)
+    {:ok, db} = CubDB.start_link(tmp_dir)
+    assert {:ok, [{^key, 123}]} = CubDB.select(db)
   end
 
   test "select/2 works as expected", %{tmp_dir: tmp_dir} do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -68,6 +68,10 @@ defmodule TestHelper do
       {Store.put_node(store, node), node}
     end
 
+    defp load_node(store, @deleted) do
+      {Store.put_node(store, @deleted), @deleted}
+    end
+
     defp load_node(store, value) do
       node = {@value, value}
       {Store.put_node(store, node), node}


### PR DESCRIPTION
`CubDB.put_new/3` inserts an entry only if it does not exists yet. It is
equivalent to atomically checking if the key exists, and setting it if
does not, but it is more efficient, as it only performs the lookup once.