### PR TITLE
Fix compaction race condition

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule CubDB.Mixfile do
     [
       app: :cubdb,
       version: "1.0.0-rc.3",
-      elixir: "~> 1.6",
+      elixir: "~> 1.7",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       elixirc_paths: elixirc_paths(Mix.env),


### PR DESCRIPTION
The compaction process actually happens in two phases: actual
compaction, and catch-up.

The previous implementation was starting the catch-up phase
asynchronously, introducing a race condition: right after actual
compaction completed, and before catch-up started, there was the
possibility to erroneously start another concurrent compaction process,
because the check if there is a compaction process already running
would return `false`. This race condition was more likely to occur when
running a compaction during heavy write load.

This PR removes the race condition.