### PR TITLE
Avoid committing unnecessary empty transaction when updating with no actual change

### DIFF
--- a/lib/cubdb.ex
+++ b/lib/cubdb.ex
@@ -518,9 +518,9 @@ defmodule CubDB do
              value = Map.get(entries, key, nil)
 
              case fun.(value) do
-               {result, ^value} -> {result, %{}, []}
+               {result, ^value} -> {result, [], []}
                {result, new_value} -> {result, %{key => new_value}, []}
-               :pop -> {value, %{}, [key]}
+               :pop -> {value, [], [key]}
              end
            end),
          do: {:ok, result}
@@ -1008,6 +1008,9 @@ defmodule CubDB do
   end
 
   @spec do_put_and_delete_multi(State.t(), [entry], [key]) :: State.t()
+
+  defp do_put_and_delete_multi(state, [], []), do: state
+  defp do_put_and_delete_multi(state, entries_to_put, []) when entries_to_put == %{}, do: state
 
   defp do_put_and_delete_multi(state, entries_to_put, keys_to_delete) do
     %State{btree: btree, auto_file_sync: auto_file_sync} = state

--- a/test/cubdb_test.exs
+++ b/test/cubdb_test.exs
@@ -350,11 +350,11 @@ defmodule CubDBTest do
 
     :ok = CubDB.put(db, :a, 1)
 
-    state = :sys.get_state(db)
+    {:ok, file_stat} = CubDB.current_db_file(db) |> File.stat()
 
     {:ok, 123} = CubDB.get_and_update(db, :a, fn x -> {123, x} end)
 
-    assert ^state = :sys.get_state(db)
+    assert {:ok, ^file_stat} = CubDB.current_db_file(db) |> File.stat()
     assert 1 = CubDB.get(db, :a)
   end
 

--- a/test/cubdb_test.exs
+++ b/test/cubdb_test.exs
@@ -351,10 +351,12 @@ defmodule CubDBTest do
     :ok = CubDB.put(db, :a, 1)
 
     {:ok, file_stat} = CubDB.current_db_file(db) |> File.stat()
+    state = :sys.get_state(db)
 
     {:ok, 123} = CubDB.get_and_update(db, :a, fn x -> {123, x} end)
 
     assert {:ok, ^file_stat} = CubDB.current_db_file(db) |> File.stat()
+    assert ^state = :sys.get_state(db)
     assert 1 = CubDB.get(db, :a)
   end
 


### PR DESCRIPTION
Update functions were committing a transaction (and therefore writing a
new header) even in case nothing was written. This pull request fixes that.