### PR TITLE
fix file descriptor leak

### DIFF
--- a/lib/cubdb.ex
+++ b/lib/cubdb.ex
@@ -1118,11 +1118,18 @@ defmodule CubDB do
 
   @spec finalize_compaction(Btree.t()) :: Btree.t()
 
-  defp finalize_compaction(btree = %Btree{store: %Store.File{file_path: file_path}}) do
+  defp finalize_compaction(btree = %Btree{store: compacted_store}) do
     Btree.sync(btree)
+    Store.close(compacted_store)
 
-    new_path = String.replace_suffix(file_path, @compaction_file_extension, @db_file_extension)
-    :ok = File.rename(file_path, new_path)
+    new_path =
+      String.replace_suffix(
+        compacted_store.file_path,
+        @compaction_file_extension,
+        @db_file_extension
+      )
+
+    :ok = File.rename(compacted_store.file_path, new_path)
 
     {:ok, store} = Store.File.create(new_path)
     Btree.new(store)

--- a/lib/cubdb/btree.ex
+++ b/lib/cubdb/btree.ex
@@ -234,6 +234,12 @@ defmodule CubDB.Btree do
     Store.close(store)
   end
 
+  @spec alive?(Btree.t()) :: boolean
+
+  def alive?(%Btree{store: store}) do
+    Store.alive?(store)
+  end
+
   def __leaf__, do: @leaf
   def __branch__, do: @branch
   def __value__, do: @value

--- a/lib/cubdb/btree.ex
+++ b/lib/cubdb/btree.ex
@@ -237,7 +237,7 @@ defmodule CubDB.Btree do
   @spec alive?(Btree.t()) :: boolean
 
   def alive?(%Btree{store: store}) do
-    Store.alive?(store)
+    Store.open?(store)
   end
 
   def __leaf__, do: @leaf

--- a/lib/cubdb/store.ex
+++ b/lib/cubdb/store.ex
@@ -28,6 +28,6 @@ defprotocol CubDB.Store do
   @spec blank?(t) :: boolean
   def blank?(store)
 
-  @spec alive?(t) :: boolean
-  def alive?(store)
+  @spec open?(t) :: boolean
+  def open?(store)
 end

--- a/lib/cubdb/store.ex
+++ b/lib/cubdb/store.ex
@@ -27,4 +27,7 @@ defprotocol CubDB.Store do
 
   @spec blank?(t) :: boolean
   def blank?(store)
+
+  @spec alive?(t) :: boolean
+  def alive?(store)
 end

--- a/lib/cubdb/store/file.ex
+++ b/lib/cubdb/store/file.ex
@@ -118,7 +118,7 @@ defimpl CubDB.Store, for: CubDB.Store.File do
     end
   end
 
-  def alive?(%Store.File{pid: pid}) do
+  def open?(%Store.File{pid: pid}) do
     Process.alive?(pid)
   end
 

--- a/lib/cubdb/store/file.ex
+++ b/lib/cubdb/store/file.ex
@@ -118,6 +118,10 @@ defimpl CubDB.Store, for: CubDB.Store.File do
     end
   end
 
+  def alive?(%Store.File{pid: pid}) do
+    Process.alive?(pid)
+  end
+
   defp read_term(file, location) do
     with {:ok, <<length::32>>, len} <- read_blocks(file, location, 4),
          {:ok, bytes, _} <- read_blocks(file, location + len, length) do

--- a/lib/cubdb/store/test_store.ex
+++ b/lib/cubdb/store/test_store.ex
@@ -65,4 +65,8 @@ defimpl CubDB.Store, for: CubDB.Store.TestStore do
       _ -> false
     end, :infinity)
   end
+
+  def alive?(%TestStore{agent: agent}) do
+    Process.alive?(agent)
+  end
 end

--- a/lib/cubdb/store/test_store.ex
+++ b/lib/cubdb/store/test_store.ex
@@ -66,7 +66,7 @@ defimpl CubDB.Store, for: CubDB.Store.TestStore do
     end, :infinity)
   end
 
-  def alive?(%TestStore{agent: agent}) do
+  def open?(%TestStore{agent: agent}) do
     Process.alive?(agent)
   end
 end

--- a/test/cubdb/btree_test.exs
+++ b/test/cubdb/btree_test.exs
@@ -495,4 +495,13 @@ defmodule CubDB.BtreeTest do
     assert {^value_marker, nil} = Btree.value()
     assert {^value_marker, "hello"} = Btree.value(val: "hello")
   end
+
+  test "Btree.alive? returns true if the Store is open, otherwise false" do
+    {:ok, store} = Store.TestStore.create()
+    btree = Btree.new(store)
+    assert Btree.alive?(btree) == true
+
+    Store.close(store)
+    assert Btree.alive?(btree) == false
+  end
 end

--- a/test/cubdb/store/file_test.exs
+++ b/test/cubdb/store/file_test.exs
@@ -72,6 +72,14 @@ defmodule CubDB.Store.FileTest do
     assert Process.alive?(pid) == false
   end
 
+  test "open?/1 returns true if the agent is alive, false otherwise", %{store: store} do
+    assert CubDB.Store.open?(store) == true
+
+    CubDB.Store.close(store)
+
+    assert CubDB.Store.open?(store) == false
+  end
+
   test "returns error if the same file is already in use by another store", %{file_path: file_path} do
     assert {:error, {%ArgumentError{message: message}, _}} = CubDB.Store.File.create(file_path)
     assert message == "file \"#{file_path}\" is already in use by another CubDB.Store.File"

--- a/test/cubdb/store/test_store_test.exs
+++ b/test/cubdb/store/test_store_test.exs
@@ -22,4 +22,12 @@ defmodule CubDB.Store.TestStoreTest do
 
     assert Process.alive?(pid) == false
   end
+
+  test "open?/1 returns true if the agent is alive, false otherwise", %{store: store} do
+    assert CubDB.Store.open?(store) == true
+
+    CubDB.Store.close(store)
+
+    assert CubDB.Store.open?(store) == false
+  end
 end

--- a/test/cubdb_test.exs
+++ b/test/cubdb_test.exs
@@ -473,6 +473,7 @@ defmodule CubDBTest do
     assert_receive :catch_up_completed, 1000
     assert_receive :clean_up_started, 1000
 
+    assert Process.alive?(old_btree.store.pid) == false
     assert CubDB.Btree.alive?(old_btree) == false
     assert %CubDB.State{old_btrees: []} = :sys.get_state(db)
   end


### PR DESCRIPTION
when cleaning up old files, the corresponding `Store` should also be
stopped, releasing the file descriptor. This step was missing, leading
to a file descriptor leak that would manifest after many compactions.

Now the `CubDB` process keeps a list of old `Btree`s, and stops them
(closing the relative `Store`) upon cleanup, after ensuring that those
`Btree`s and their files are not in use anymore by any reader.

Resolves #30 