### PR TITLE
Abstract storage engine as an option

### DIFF
--- a/lib/cubdb/btree.ex
+++ b/lib/cubdb/btree.ex
@@ -28,7 +28,7 @@ defmodule CubDB.Btree do
   @type val :: CubDB.value()
   @type btree_size :: non_neg_integer
   @type dirt :: non_neg_integer
-  @type location :: non_neg_integer
+  @type location :: any
   @type capacity :: pos_integer
   @type child_pointer :: {key, location}
   @type leaf_node :: record(:leaf, children: [child_pointer])

--- a/lib/cubdb/store.ex
+++ b/lib/cubdb/store.ex
@@ -7,6 +7,21 @@ defprotocol CubDB.Store do
 
   alias CubDB.Btree
 
+  @spec identifier(t) :: String.t()
+  def identifier(store)
+
+  @spec next_compaction_store(t) :: t
+  def next_compaction_store(store)
+
+  @spec start_cleanup(t) :: {:ok, pid} | {:error, String.t()}
+  def start_cleanup(t)
+
+  @spec clean_up_old_compaction_files(t, pid) :: :ok | {:error, String.t()}
+  def clean_up_old_compaction_files(t, cleanup)
+
+  @spec clean_up(t, pid, Btree.btree_node()) :: :ok | {:error, String.t()}
+  def clean_up(t, cleanup, btree)
+
   @spec put_node(t, Btree.btree_node()) :: Btree.location()
   def put_node(store, node)
 

--- a/lib/cubdb/store/file/clean_up.ex
+++ b/lib/cubdb/store/file/clean_up.ex
@@ -1,4 +1,4 @@
-defmodule CubDB.CleanUp do
+defmodule CubDB.Store.File.CleanUp do
   @moduledoc false
 
   # The `CubDB.CleanUp` module takes care of cleaning up obsolete files, like

--- a/lib/cubdb/store/test_store.ex
+++ b/lib/cubdb/store/test_store.ex
@@ -23,6 +23,26 @@ end
 defimpl CubDB.Store, for: CubDB.Store.TestStore do
   alias CubDB.Store.TestStore
 
+  def identifier(%TestStore{agent: pid}) do
+    "#{pid}"
+  end
+
+  def clean_up(_store, cpid, btree) do
+    :ok
+  end
+
+  def clean_up_old_compaction_files(store, pid) do
+    :ok
+  end
+
+  def start_cleanup(%TestStore{}) do
+    {:ok, nil}
+  end
+
+  def next_compaction_store(%TestStore{}) do
+    Store.TestStore.create()
+  end
+
   def put_node(%TestStore{agent: agent}, node) do
     Agent.get_and_update(
       agent,


### PR DESCRIPTION
Hello,

Congrats on the great project! I am using it in something I am developing and thought I would contribute the changes upstream.

I wanted to abstract away the storage engine to be an option. I am using CubDB to build P2P sharable immutable trees: https://github.com/SoCal-Software-Labs/CrissCross  

A simple example of how to build a merkle tree with CubDB with these changes:

https://gist.github.com/hansonkd/a0a974704a8483216dca2a1e79c00e62

I think this is really powerful because it allows you to abstract KV stores on top of whatever backend you want (you can add layers of caching or other middlewares too)

In addition the location type should be dependent on the store. That way a store can have whatever location object type it wants.
