### PR TITLE
Simplify and improve reader logic using snapshotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ releases](https://github.com/lucaong/cubdb/releases).
 Since `v1.0.0`, `CubDB` follows [semantic versioning](https://semver.org), and
 reports changes here.
 
+## next
+
+  - [breaking] Remove the `:timeout` option on `select/2`. This is part of a
+    refactoring and improvement that moves read operations from an
+    internally spawned Task to the client process. This makes the `:timeout`
+    option unnecessary, because the user now has complete control: by stopping
+    the process calling `CubDB`, any running read operation by that process is
+    stopped.
+  - Add the possibility to get zero-cost snapshots of the database, and perform
+    reads on them to ensure consistency of dependent reads. This is done via the
+    functions `snapshot/2`, `with_snapshot/1` and `release_snapshot/1`
+  - Add `halt_compaction/1` to stop any running compaction operation
+  - Add `compacting?/1` to check if a compaction is currently running
+
 ## v1.1.0 (2021-10-14)
 
   - Add `clear/1` function to atomically delete all entries in the database

--- a/lib/cubdb/reader.ex
+++ b/lib/cubdb/reader.ex
@@ -2,15 +2,8 @@ defmodule CubDB.Reader do
   @moduledoc false
 
   # The `CubDB.Reader` module performs all read operations that involve access
-  # to the store. Each read operation is ran in its own process, as a `Task`, so
-  # that read operations can run concurrently. Read operations are performed on
-  # the Btree representing a snapshot of the database at the time the read
-  # operation was invoked.
-  #
-  # The Reader processes are monitored by the main db process. That allows the
-  # main process to keep track of which files are still referenced by readers,
-  # so that clean-up of old files after a compaction can be delayed until no
-  # more `Reader` processes reference them.
+  # to the store. Read operations are performed on the Btree representing a
+  # snapshot of the database at the time the read operation was invoked.
 
   alias CubDB.Btree
 
@@ -20,12 +13,6 @@ defmodule CubDB.Reader do
           | {:fetch, CubDB.key()}
           | {:has_key?, CubDB.key()}
           | {:select, Keyword.t()}
-
-  @spec run(Btree.t(), GenServer.from(), operation) :: :ok
-
-  def run(btree, caller, operation) do
-    GenServer.reply(caller, perform(btree, operation))
-  end
 
   @spec perform(Btree.t(), operation) :: any
 

--- a/test/cubdb/reader_test.exs
+++ b/test/cubdb/reader_test.exs
@@ -5,27 +5,6 @@ defmodule CubDB.Store.ReaderTest do
   alias CubDB.Reader
   alias CubDB.Store
 
-  defmodule TestCaller do
-    use GenServer
-
-    def start_link do
-      GenServer.start_link(__MODULE__, [], [])
-    end
-
-    def run(pid, btree, operation) do
-      GenServer.call(pid, {:run, btree, operation})
-    end
-
-    def init(_) do
-      {:ok, nil}
-    end
-
-    def handle_call({:run, btree, operation}, from, state) do
-      Reader.run(btree, from, operation)
-      {:noreply, state}
-    end
-  end
-
   setup do
     {:ok, store} = Store.TestStore.create()
 
@@ -126,10 +105,5 @@ defmodule CubDB.Store.ReaderTest do
 
   test "perform/2 performs :select with invalid :pipe", %{btree: btree} do
     assert {:error, _} = Reader.perform(btree, {:select, pipe: [xxx: 123]})
-  end
-
-  test "run/3 performs the read and replies to the caller GenServer", %{btree: btree} do
-    {:ok, pid} = TestCaller.start_link()
-    assert {:ok, [c: 3, d: 4]} = TestCaller.run(pid, btree, {:select, pipe: [take: 4, drop: 2]})
   end
 end


### PR DESCRIPTION
Before, read operations were executed on a Task spawned by the GenServer
server process, to enable concurrency. This required monitoring reader
tasks, and updating the bookkeeping information to prevent clean up of
files that are still referenced by some reader.

Now, read operations are executed by the GenServer client process, after
obtaining a snapshot (or on the given snapshot). This enables
concurrency without the need of reader tasks, and simplifies the whole
flow. Bookkeeping is perfomed by the snapshot logic, so no additional
process or monitor is necessary.

For the user, nothing changes, apart from one single breaking change:
the `select` function does not support anymore passing a `:timeout`
option. While this is considered a breaking change, now the select
happens on the client process, so the user has complete control and can
enforce timeouts or stop the process, without the need of a specific
option to shutdown the internal reader Task.