### PR TITLE
Improve concurrency of readers while writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ reports changes here.
     block readers or writers, and is isolated from concurrent writes.
   - Add `halt_compaction/1` to stop any running compaction operation
   - Add `compacting?/1` to check if a compaction is currently running
+  - Improve concurrency of read operations while writing
 
 ## v1.1.0 (2021-10-14)
 


### PR DESCRIPTION
By executing writes on the caller process as opposed to the `CubDB` server process, and controlling access with a write lock logic. This makes it possible to start read operations while a write operation is ongoing, while ensuring that other write operations are still serialized.