### PR TITLE
Move functions that read from snapshots in the CubDB.Snapshot module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ reports changes here.
     unnecessary: by stopping the process calling `CubDB`, any running read
     operation by that process is stopped.
   - Add `snapshot/2`, `with_snapshot/1` and `release_snapshot/1` to get zero
-    cost read only snapshots of the database.
+    cost read-only snapshots of the database. The functions in `CubDB.Snapshot`
+    allow to read from a snapshot.
   - Add `back_up/2` to produce a database backup. The backup process does not
     block readers or writers, and is isolated from concurrent writes.
   - Add `halt_compaction/1` to stop any running compaction operation

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ disk or in memory, apart from some small bookkeeping:
 # the key of y depends on the value of x, so we ensure consistency by getting
 # them from the same snapshot, isolating from the effects of concurrent writes
 {x, y} = CubDB.with_snapshot(db, fn snap ->
-  x = CubDB.get(snap, :x)
-  y = CubDB.get(snap, x)
+  x = CubDB.Snapshot.get(snap, :x)
+  y = CubDB.Snapshot.get(snap, x)
 
   {x, y}
 end)

--- a/lib/cubdb/snapshot.ex
+++ b/lib/cubdb/snapshot.ex
@@ -1,0 +1,154 @@
+defmodule CubDB.Snapshot do
+  alias CubDB.Btree
+  alias CubDB.Store
+  alias CubDB.Snapshot
+  alias CubDB.Reader
+
+  @db_file_extension ".cub"
+
+  @enforce_keys [:db, :btree, :reader_ref]
+  defstruct [
+    :db,
+    :btree,
+    :reader_ref
+  ]
+
+  @typep snapshot :: %Snapshot{
+           db: GenServer.server(),
+           btree: Btree.t(),
+           reader_ref: reference
+         }
+
+  @type t :: snapshot
+
+  @spec get(Snapshot.t(), CubDB.key(), CubDB.value()) :: CubDB.value()
+
+  @doc """
+  Gets the value associated to `key` from the snapshot.
+
+  If no value is associated with `key`, `default` is returned (which is `nil`,
+  unless specified otherwise).
+
+  It works the same as `CubDB.get/3`, but reads from a snapshot instead of the
+  live database.
+  """
+  def get(%Snapshot{} = snapshot, key, default \\ nil) do
+    extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
+      Reader.perform(btree, {:get, key, default})
+    end)
+  end
+
+  @spec get_multi(Snapshot.t(), [CubDB.key()]) :: %{CubDB.key() => CubDB.value()}
+
+  @doc """
+  Gets multiple entries corresponding by the given keys from the snapshot all at
+  once, atomically.
+
+  It works the same as `CubDB.get_multi/2`, but reads from a snapshot instead of
+  the live database.
+  """
+  def get_multi(%Snapshot{} = snapshot, keys) do
+    extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
+      Reader.perform(btree, {:get_multi, keys})
+    end)
+  end
+
+  @spec fetch(Snapshot.t(), CubDB.key()) :: {:ok, CubDB.value()} | :error
+
+  @doc """
+  Fetches the value for the given `key` from the snapshot, or returns `:error`
+  if `key` is not present.
+
+  If the snapshot contains an entry with the given `key` and value `value`, it
+  returns `{:ok, value}`. If `key` is not found, it returns `:error`.
+
+  It works the same as `CubDB.fetch/2`, but reads from a snapshot instead of
+  the live database.
+  """
+  def fetch(%Snapshot{} = snapshot, key) do
+    extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
+      Reader.perform(btree, {:fetch, key})
+    end)
+  end
+
+  @spec has_key?(Snapshot.t(), CubDB.key()) :: boolean
+
+  @doc """
+  Returns whether an entry with the given `key` exists in the snapshot.
+
+  It works the same as `CubDB.has_key?/2`, but reads from a snapshot instead of
+  the live database.
+  """
+  def has_key?(%Snapshot{} = snapshot, key) do
+    extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
+      Reader.perform(btree, {:has_key?, key})
+    end)
+  end
+
+  @spec select(Snapshot.t(), [CubDB.select_option()]) ::
+          {:ok, any} | {:error, Exception.t()}
+
+  @doc """
+  Selects a range of entries from the snapshot, and optionally performs a
+  pipeline of operations on them.
+
+  It returns `{:ok, result}` if successful, or `{:error, exception}` if an
+  exception is raised.
+
+  It works the same and accepts the same options as `CubDB.select/2`, but reads
+  from a snapshot instead of the live database.
+  """
+  def select(%Snapshot{} = snapshot, options \\ []) when is_list(options) do
+    extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
+      Reader.perform(btree, {:select, options})
+    end)
+  end
+
+  @spec size(Snapshot.t()) :: non_neg_integer
+
+  @doc """
+  Returns the number of entries present in the snapshot.
+
+  It works the same as `CubDB.size/1`, but works on a snapshot instead of the
+  live database.
+  """
+  def size(%Snapshot{} = snapshot) do
+    extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
+      Enum.count(btree)
+    end)
+  end
+
+  @spec back_up(Snapshot.t(), Path.t()) :: :ok | {:error, term}
+
+  @doc """
+  Creates a backup of the snapshot into the target directory path
+
+  It works the same as `CubDB.back_up/2`, but works on a snapshot instead of the
+  live database.
+  """
+  def back_up(%Snapshot{} = snapshot, target_path) do
+    extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
+      with :ok <- File.mkdir(target_path),
+           {:ok, store} <- Store.File.create(Path.join(target_path, "0#{@db_file_extension}")) do
+        Btree.load(btree, store) |> Btree.sync()
+        Store.close(store)
+      end
+    end)
+  end
+
+  @spec extend_snapshot(Snapshot.t(), (Snapshot.t() -> result)) :: result when result: any
+
+  defp extend_snapshot(snapshot = %Snapshot{db: db}, fun) do
+    case GenServer.call(db, {:extend_snapshot, snapshot}, :infinity) do
+      {:ok, snap} ->
+        try do
+          fun.(snap)
+        after
+          CubDB.release_snapshot(snap)
+        end
+
+      _ ->
+        raise "Attempt to use CubDB snapshot after it was released or it timed out"
+    end
+  end
+end

--- a/test/cubdb/compactor_test.exs
+++ b/test/cubdb/compactor_test.exs
@@ -1,4 +1,4 @@
-defmodule CubDB.Store.CompactorTest do
+defmodule CubDB.CompactorTest do
   use ExUnit.Case
 
   alias CubDB.Btree

--- a/test/cubdb/snapshot_test.exs
+++ b/test/cubdb/snapshot_test.exs
@@ -1,0 +1,102 @@
+defmodule CubDB.SnapshotTest do
+  use ExUnit.Case
+
+  setup do
+    {tmp_dir, 0} = System.cmd("mktemp", ["-d"])
+    tmp_dir = tmp_dir |> String.trim()
+
+    on_exit(fn ->
+      File.rm_rf!(tmp_dir)
+    end)
+
+    {:ok, tmp_dir: tmp_dir}
+  end
+
+  test "get, get_multi, fetch, has_key?, size work as expected", %{tmp_dir: tmp_dir} do
+    {:ok, db} = CubDB.start_link(tmp_dir)
+    CubDB.put_multi(db, a: 1, c: 3)
+
+    snap = CubDB.snapshot(db)
+    :ok = CubDB.put_multi(db, a: 2, b: 3)
+
+    assert 1 = CubDB.Snapshot.get(snap, :a)
+    assert 0 = CubDB.Snapshot.get(snap, :b, 0)
+
+    assert %{:a => 1, :c => 3} = CubDB.Snapshot.get_multi(snap, [:a, :b, :c])
+
+    assert {:ok, 1} = CubDB.Snapshot.fetch(snap, :a)
+    assert :error = CubDB.Snapshot.fetch(snap, :b)
+
+    assert CubDB.Snapshot.has_key?(snap, :a)
+    refute CubDB.Snapshot.has_key?(snap, :b)
+
+    assert 2 = CubDB.Snapshot.size(snap)
+
+    assert 2 = CubDB.get(db, :a)
+    assert 3 = CubDB.get(db, :b)
+    assert 3 = CubDB.size(db)
+  end
+
+  test "read operations extend the validity of the snapshot until the end of the read operation",
+       %{tmp_dir: tmp_dir} do
+    {:ok, db} = CubDB.start_link(tmp_dir)
+    CubDB.subscribe(db)
+
+    CubDB.put_multi(db, a: 1, b: 2, c: 3, d: 4, e: 5)
+
+    snap = CubDB.snapshot(db, 50)
+    :ok = CubDB.compact(db)
+
+    {:ok, result} =
+      CubDB.Snapshot.select(snap,
+        pipe: [
+          map: fn x ->
+            Process.sleep(20)
+            x
+          end
+        ]
+      )
+
+    assert result == [a: 1, b: 2, c: 3, d: 4, e: 5]
+    assert_receive :clean_up_started, 1000
+  end
+
+  describe "back_up/2" do
+    setup do
+      {backup_dir, 0} = System.cmd("mktemp", ["-d"])
+      backup_dir = String.trim(backup_dir)
+
+      on_exit(fn ->
+        File.rm_rf!(backup_dir)
+      end)
+
+      {:ok, backup_dir: backup_dir}
+    end
+
+    test "returns error tuple if the target directory already exists", %{
+      tmp_dir: tmp_dir,
+      backup_dir: backup_dir
+    } do
+      {:ok, db} = CubDB.start_link(data_dir: tmp_dir)
+      snap = CubDB.snapshot(db)
+      assert {:error, :eexist} = CubDB.Snapshot.back_up(snap, backup_dir)
+    end
+
+    test "creates a backup of the given snapshot", %{tmp_dir: tmp_dir, backup_dir: backup_dir} do
+      File.rm_rf!(backup_dir)
+      {:ok, db} = CubDB.start_link(data_dir: tmp_dir)
+
+      :ok = CubDB.put_multi(db, foo: 1, bar: 2, baz: 3)
+
+      CubDB.with_snapshot(db, fn snap ->
+        :ok = CubDB.put_multi(db, foo: 0, qux: 4)
+
+        assert :ok = CubDB.Snapshot.back_up(snap, backup_dir)
+
+        {:ok, copy} = CubDB.start_link(data_dir: backup_dir)
+
+        assert CubDB.Snapshot.select(snap) == CubDB.select(copy)
+      end)
+    end
+  end
+end


### PR DESCRIPTION
This is to avoid confusion between reading from the live database and
reading from a snapshot.