### PR TITLE
Add CubDB.Tx.refetch/3

### DIFF
--- a/lib/cubdb/transaction.ex
+++ b/lib/cubdb/transaction.ex
@@ -89,6 +89,13 @@ defmodule CubDB.Tx do
   with respect to a snapshot: using `refetch/3` can save some disk access if
   `CubDB` is able to determine that the key was not written since the snapshot.
 
+  In some situations, such as when the entry is not present in the database, or
+  when a compaction completed after `snapshot`, the function cannot determine if
+  the entry was written or not since `snapshot`, and therefore fetches it. In
+  other words, `refetch/3` is a performance optimization to save some disk reads
+  when possible, but it might fetch an entry even if it technically did not
+  change.
+
   ## Example
 
   The function `refetch/3` can be useful when implementing optimistic

--- a/test/cubdb/transaction_test.exs
+++ b/test/cubdb/transaction_test.exs
@@ -46,15 +46,18 @@ defmodule CubDB.TransactionTest do
     tmp_dir: tmp_dir
   } do
     {:ok, db} = CubDB.start_link(data_dir: tmp_dir, auto_compact: false)
-    :ok = CubDB.put_multi(db, a: 1, b: 2, c: 3)
+    :ok = CubDB.put_multi(db, a: 1, b: 2, c: 3, d: 4)
 
     CubDB.with_snapshot(db, fn snap ->
       :ok = CubDB.put_multi(db, b: 0, c: 3)
+      :ok = CubDB.delete(db, :d)
 
       CubDB.transaction(db, fn tx ->
         assert :unchanged = CubDB.Tx.refetch(tx, :a, snap)
         assert {:ok, 0} = CubDB.Tx.refetch(tx, :b, snap)
         assert {:ok, 3} = CubDB.Tx.refetch(tx, :c, snap)
+        assert :error = CubDB.Tx.refetch(tx, :d, snap)
+        assert :error = CubDB.Tx.refetch(tx, :e, snap)
 
         {:cancel, nil}
       end)


### PR DESCRIPTION
The function `refetch/3` checks if an entry has been written since the
point in time represented by the given snapshot. If not, it returns
`:unchanged`, otherwise it fetches the entry from the transaction.

The check if the entry was written is performed without reading the
whole entry from disk, and instead only looking at index pages.

This function can be useful to implement optimistic concurrency control,
when one computes the update to an entry outside of a transaction to
avoid blocking writers, then opens a transaction and checks if the value
changed in the meanwhile (and if so, recomputes the update). In these
cases, using `refetch/3` can improve performance, especially when the
value is large, by avoiding to read the value from disk if `CubDB` can
determine that it was not written by looking just at the index pages.