### PR TITLE
CubDB.select/2 returns a lazy stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Version `2.0.0` brings better concurrency, atomic transactions with arbitrary
 operations, zero cost read-only snapshots, database backup, and more, all with a
 simpler and more scalable internal architecture.
 
+Refer to the [upgrade guide](https://hexdocs.pm/cubdb/upgrading.html) for how to
+upgrade from previous versions.
+
   - [breaking] The functions `get_and_update/3`, `get_and_update_multi/3`, and
     `select/2` now return directly `result`, instead of a `{:ok, result}` tuple.
   - [breaking] `get_and_update_multi/4` does not take an option argument
@@ -22,6 +25,9 @@ simpler and more scalable internal architecture.
     spawned `Task` to the client process. This makes the `:timeout` option
     unnecessary: by stopping the process calling `CubDB`, any running read
     operation by that process is stopped.
+  - [breaking] `select/2` now returns a lazy stream that can be used with
+    functions in `Enum` and `Stream`. This makes the `:pipe` and `:reduce`
+    options unnecessary, so those options were removed.
   - Add `snapshot/2`, `with_snapshot/1` and `release_snapshot/1` to get zero
     cost read-only snapshots of the database. The functions in `CubDB.Snapshot`
     allow to read from a snapshot.
@@ -35,22 +41,6 @@ simpler and more scalable internal architecture.
   - Move read and write operations to the caller process as opposed to the
     `CubDB` server process.
   - Improve concurrency of read operations while writing
-
-### Upgrading from v1 to v2
-
-Upgrading from `v1` to `v2` requires a few simple code changes:
-
-  1. When calling `get_and_update`, `get_and_update_multi`, and `select` the
-     return value is not a `{:ok, result}` tuple anymore, but just `result`.
-  2. `get_and_update_multi` does not take a fourth option argument anymore. The
-     only available option was `:timeout`, which was now removed. In case you
-     want to enforce a timeout for the update function, you can use a `Task` and
-     `Task.yield` like explained
-     [here](https://hexdocs.pm/elixir/1.12/Task.html#yield/2).
-  3. The `select` function does not support a `:timeout` option anymore, so it
-     will be ignored if passed. In order to enforce a timeout, you can wrap the
-     `select` in a `Task` and use `Task.yield` like shown
-     [here](https://hexdocs.pm/elixir/1.12/Task.html#yield/2)
 
 ## v1.1.0 (2021-10-14)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,45 @@
+# Upgrading from v1 to v2
+
+The database format is completely backward compatible, so version `v2` of
+`CubDB` can load databases created with `v1`, and vice-versa. Upgrading from
+`v1` to `v2` requires a few code changes though, as some functions changed
+signature.
+
+When calling `get_and_update`, `get_and_update_multi`, and `select` the return
+value is not a `{:ok, result}` tuple anymore, but just `result`.
+
+The function `get_and_update_multi` does not take a fourth option argument
+anymore. The only available option was `:timeout`, which was now removed. In
+case you want to enforce a timeout for the update function, you can use a `Task`
+and `Task.yield` like explained
+[here](https://hexdocs.pm/elixir/1.12/Task.html#yield/2).
+
+The `select` function does not accept the `:pipe` and `:reduce` options anymore.
+Instead, it returns a lazy stream that can be used with functions in the
+`Stream` and `Enum` modules. For example:
+
+```elixir
+# This v1 code:
+{:ok, product} =
+  CubDB.select(db, [
+    min_key: :foo,
+    max_key: :bar,
+    pipe: [
+      map: fn {_, val} -> val end,
+      filter: fn val -> val > 0 end
+    ],
+    reduce: fn val, acc -> val * acc end
+  ])
+
+# Can be rewritten to this code in v2:
+product =
+  CubDB.select(db, min_key: :foo, max_key: :bar)
+  |> Stream.map(fn {_, val} -> val end)
+  |> Stream.filter(fn val -> val > 0 end)
+  |> Enum.reduce(fn val, acc -> val * acc end)
+```
+
+The `select` function also does not support a `:timeout` option anymore, so it
+will be ignored if passed. In order to enforce a timeout, you can wrap the
+`select` in a `Task` and use `Task.yield` like shown
+[here](https://hexdocs.pm/elixir/1.12/Task.html#yield/2)

--- a/lib/cubdb/reader.ex
+++ b/lib/cubdb/reader.ex
@@ -56,6 +56,32 @@ defmodule CubDB.Reader do
   @spec select(Btree.t(), [CubDB.select_option()]) :: any
 
   def select(btree, options) when is_list(options) do
+    pipe = Keyword.get(options, :pipe, [])
+    reduce = Keyword.get(options, :reduce)
+
+    key_range = select_stream(btree, options)
+
+    stream =
+      Enum.reduce(pipe, key_range, fn
+        {:filter, fun}, stream when is_function(fun) -> Stream.filter(stream, fun)
+        {:map, fun}, stream when is_function(fun) -> Stream.map(stream, fun)
+        {:take, n}, stream when is_integer(n) -> Stream.take(stream, n)
+        {:drop, n}, stream when is_integer(n) -> Stream.drop(stream, n)
+        {:take_while, fun}, stream when is_function(fun) -> Stream.take_while(stream, fun)
+        {:drop_while, fun}, stream when is_function(fun) -> Stream.drop_while(stream, fun)
+        op, _ -> raise(ArgumentError, message: "invalid pipe operation #{inspect(op)}")
+      end)
+
+    case reduce do
+      fun when is_function(fun) -> Enum.reduce(stream, fun)
+      {acc, fun} when is_function(fun) -> Enum.reduce(stream, acc, fun)
+      nil -> Enum.to_list(stream)
+    end
+  end
+
+  @spec select_stream(Btree.t(), [CubDB.select_option()]) :: Enumerable.t()
+
+  def select_stream(btree, options) when is_list(options) do
     min_key =
       case Keyword.fetch(options, :min_key) do
         {:ok, key} ->
@@ -74,27 +100,8 @@ defmodule CubDB.Reader do
           nil
       end
 
-    pipe = Keyword.get(options, :pipe, [])
-    reduce = Keyword.get(options, :reduce)
     reverse = Keyword.get(options, :reverse, false)
 
-    key_range = Btree.key_range(btree, min_key, max_key, reverse)
-
-    stream =
-      Enum.reduce(pipe, key_range, fn
-        {:filter, fun}, stream when is_function(fun) -> Stream.filter(stream, fun)
-        {:map, fun}, stream when is_function(fun) -> Stream.map(stream, fun)
-        {:take, n}, stream when is_integer(n) -> Stream.take(stream, n)
-        {:drop, n}, stream when is_integer(n) -> Stream.drop(stream, n)
-        {:take_while, fun}, stream when is_function(fun) -> Stream.take_while(stream, fun)
-        {:drop_while, fun}, stream when is_function(fun) -> Stream.drop_while(stream, fun)
-        op, _ -> raise(ArgumentError, message: "invalid pipe operation #{inspect(op)}")
-      end)
-
-    case reduce do
-      fun when is_function(fun) -> Enum.reduce(stream, fun)
-      {acc, fun} when is_function(fun) -> Enum.reduce(stream, acc, fun)
-      nil -> Enum.to_list(stream)
-    end
+    Btree.key_range(btree, min_key, max_key, reverse)
   end
 end

--- a/lib/cubdb/reader.ex
+++ b/lib/cubdb/reader.ex
@@ -7,13 +7,6 @@ defmodule CubDB.Reader do
 
   alias CubDB.Btree
 
-  @type operation ::
-          {:get, CubDB.key(), CubDB.value()}
-          | {:get_multi, [CubDB.key()]}
-          | {:fetch, CubDB.key()}
-          | {:has_key?, CubDB.key()}
-          | {:select, Keyword.t()}
-
   @spec get(Btree.t(), CubDB.key(), any) :: any
 
   def get(btree, key, default) do
@@ -53,35 +46,11 @@ defmodule CubDB.Reader do
 
   def size(btree), do: Enum.count(btree)
 
-  @spec select(Btree.t(), [CubDB.select_option()]) :: any
+  @spec select(Btree.t(), [CubDB.select_option()]) :: Enumerable.t()
 
   def select(btree, options) when is_list(options) do
-    pipe = Keyword.get(options, :pipe, [])
-    reduce = Keyword.get(options, :reduce)
+    check_legacy_select_options!(options)
 
-    key_range = select_stream(btree, options)
-
-    stream =
-      Enum.reduce(pipe, key_range, fn
-        {:filter, fun}, stream when is_function(fun) -> Stream.filter(stream, fun)
-        {:map, fun}, stream when is_function(fun) -> Stream.map(stream, fun)
-        {:take, n}, stream when is_integer(n) -> Stream.take(stream, n)
-        {:drop, n}, stream when is_integer(n) -> Stream.drop(stream, n)
-        {:take_while, fun}, stream when is_function(fun) -> Stream.take_while(stream, fun)
-        {:drop_while, fun}, stream when is_function(fun) -> Stream.drop_while(stream, fun)
-        op, _ -> raise(ArgumentError, message: "invalid pipe operation #{inspect(op)}")
-      end)
-
-    case reduce do
-      fun when is_function(fun) -> Enum.reduce(stream, fun)
-      {acc, fun} when is_function(fun) -> Enum.reduce(stream, acc, fun)
-      nil -> Enum.to_list(stream)
-    end
-  end
-
-  @spec select_stream(Btree.t(), [CubDB.select_option()]) :: Enumerable.t()
-
-  def select_stream(btree, options) when is_list(options) do
     min_key =
       case Keyword.fetch(options, :min_key) do
         {:ok, key} ->
@@ -103,5 +72,19 @@ defmodule CubDB.Reader do
     reverse = Keyword.get(options, :reverse, false)
 
     Btree.key_range(btree, min_key, max_key, reverse)
+  end
+
+  @spec check_legacy_select_options!(Keyword.t()) :: :ok
+
+  defp check_legacy_select_options!(options) do
+    if Keyword.has_key?(options, :reduce) do
+      raise "select/2 does not have a :reduce option anymore. Use Enum.reduce on the returned lazy stream instead."
+    end
+
+    if Keyword.has_key?(options, :pipe) do
+      raise "select/2 does not have a :pipe option anymore. Pipe the returned lazy stream into functions in Stream or Enum instead."
+    end
+
+    :ok
   end
 end

--- a/lib/cubdb/snapshot.ex
+++ b/lib/cubdb/snapshot.ex
@@ -93,22 +93,7 @@ defmodule CubDB.Snapshot do
     end)
   end
 
-  @spec select(Snapshot.t(), [CubDB.select_option()]) :: any
-
-  @doc """
-  Selects a range of entries from the snapshot, and optionally performs a
-  pipeline of operations on them.
-
-  It works the same and accepts the same options as `CubDB.select/2`, but reads
-  from a snapshot instead of the live database.
-  """
-  def select(%Snapshot{} = snapshot, options \\ []) when is_list(options) do
-    extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
-      Reader.select(btree, options)
-    end)
-  end
-
-  @spec select_stream(GenServer.server(), [CubDB.select_option()]) :: Enumerable.t()
+  @spec select(GenServer.server(), [CubDB.select_option()]) :: Enumerable.t()
 
   @doc """
   Selects a range of entries from the snapshot, returning a lazy stream.
@@ -116,15 +101,15 @@ defmodule CubDB.Snapshot do
   The lazy stream can only be consumed while the snapshot is still valid, or a
   `RuntimeError` will be raised.
 
-  It works the same and accepts the same options as `CubDB.select_stream/2`, but
-  reads from a snapshot instead of the live database.
+  It works the same and accepts the same options as `CubDB.select/2`, but reads
+  from a snapshot instead of the live database.
   """
-  def select_stream(snap, options \\ []) when is_list(options) do
+  def select(snap, options \\ []) when is_list(options) do
     Stream.resource(
       fn ->
         snap = extend_snapshot(snap)
         %Snapshot{btree: btree} = snap
-        stream = Reader.select_stream(btree, options)
+        stream = Reader.select(btree, options)
         step = fn val, _acc -> {:suspend, val} end
         next = &Enumerable.reduce(stream, &1, step)
         {snap, next}

--- a/lib/cubdb/snapshot.ex
+++ b/lib/cubdb/snapshot.ex
@@ -1,4 +1,12 @@
 defmodule CubDB.Snapshot do
+  @moduledoc """
+  The `CubDB.Snapshot` module contains functions to read from snapshots obtained
+  with `CubDB.with_snapshot/2` or `CubDB.snapshot/2`.
+
+  The functions in this module mirror the ones with the same name in the `CubDB`
+  module, but work on snapshots instead of on the live database.
+  """
+
   alias CubDB.Btree
   alias CubDB.Store
   alias CubDB.Snapshot
@@ -32,7 +40,7 @@ defmodule CubDB.Snapshot do
   It works the same as `CubDB.get/3`, but reads from a snapshot instead of the
   live database.
   """
-  def get(%Snapshot{} = snapshot, key, default \\ nil) do
+  def get(snapshot = %Snapshot{}, key, default \\ nil) do
     extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
       Reader.get(btree, key, default)
     end)
@@ -47,7 +55,7 @@ defmodule CubDB.Snapshot do
   It works the same as `CubDB.get_multi/2`, but reads from a snapshot instead of
   the live database.
   """
-  def get_multi(%Snapshot{} = snapshot, keys) do
+  def get_multi(snapshot = %Snapshot{}, keys) do
     extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
       Reader.get_multi(btree, keys)
     end)
@@ -65,7 +73,7 @@ defmodule CubDB.Snapshot do
   It works the same as `CubDB.fetch/2`, but reads from a snapshot instead of
   the live database.
   """
-  def fetch(%Snapshot{} = snapshot, key) do
+  def fetch(snapshot = %Snapshot{}, key) do
     extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
       Reader.fetch(btree, key)
     end)
@@ -79,7 +87,7 @@ defmodule CubDB.Snapshot do
   It works the same as `CubDB.has_key?/2`, but reads from a snapshot instead of
   the live database.
   """
-  def has_key?(%Snapshot{} = snapshot, key) do
+  def has_key?(snapshot = %Snapshot{}, key) do
     extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
       Reader.has_key?(btree, key)
     end)
@@ -100,6 +108,40 @@ defmodule CubDB.Snapshot do
     end)
   end
 
+  @spec select_stream(GenServer.server(), [CubDB.select_option()]) :: Enumerable.t()
+
+  @doc """
+  Selects a range of entries from the snapshot, returning a lazy stream.
+
+  The lazy stream can only be consumed while the snapshot is still valid, or a
+  `RuntimeError` will be raised.
+
+  It works the same and accepts the same options as `CubDB.select_stream/2`, but
+  reads from a snapshot instead of the live database.
+  """
+  def select_stream(snap, options \\ []) when is_list(options) do
+    Stream.resource(
+      fn ->
+        snap = extend_snapshot(snap)
+        %Snapshot{btree: btree} = snap
+        stream = Reader.select_stream(btree, options)
+        step = fn val, _acc -> {:suspend, val} end
+        next = &Enumerable.reduce(stream, &1, step)
+        {snap, next}
+      end,
+      fn {snap, next} ->
+        case next.({:cont, nil}) do
+          {:done, _} ->
+            {:halt, {snap, nil}}
+
+          {:suspended, value, next} ->
+            {[value], {snap, next}}
+        end
+      end,
+      fn {snap, _} -> CubDB.release_snapshot(snap) end
+    )
+  end
+
   @spec size(Snapshot.t()) :: non_neg_integer
 
   @doc """
@@ -108,7 +150,7 @@ defmodule CubDB.Snapshot do
   It works the same as `CubDB.size/1`, but works on a snapshot instead of the
   live database.
   """
-  def size(%Snapshot{} = snapshot) do
+  def size(snapshot = %Snapshot{}) do
     extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
       Reader.size(btree)
     end)
@@ -122,7 +164,7 @@ defmodule CubDB.Snapshot do
   It works the same as `CubDB.back_up/2`, but works on a snapshot instead of the
   live database.
   """
-  def back_up(%Snapshot{} = snapshot, target_path) do
+  def back_up(snapshot = %Snapshot{}, target_path) do
     extend_snapshot(snapshot, fn %Snapshot{btree: btree} ->
       with :ok <- File.mkdir(target_path),
            {:ok, store} <- Store.File.create(Path.join(target_path, "0#{@db_file_extension}")) do
@@ -142,6 +184,18 @@ defmodule CubDB.Snapshot do
         after
           CubDB.release_snapshot(snap)
         end
+
+      _ ->
+        raise "Attempt to use CubDB snapshot after it was released or it timed out"
+    end
+  end
+
+  @spec extend_snapshot(Snapshot.t()) :: Snapshot.t()
+
+  defp extend_snapshot(snapshot = %Snapshot{db: db}) do
+    case GenServer.call(db, {:extend_snapshot, snapshot}, :infinity) do
+      {:ok, snap} ->
+        snap
 
       _ ->
         raise "Attempt to use CubDB snapshot after it was released or it timed out"

--- a/lib/cubdb/transaction.ex
+++ b/lib/cubdb/transaction.ex
@@ -1,14 +1,23 @@
 defmodule CubDB.Tx do
+  @moduledoc """
+  The `CubDB.Tx` module contains functions to read or write within atomic
+  transactions created with `CubDB.transaction/2`.
+
+  The functions in this module mirror the ones with the same name in the `CubDB`
+  module, but work on transactions instead of on the live database.
+  """
+
   alias CubDB.Btree
   alias CubDB.Reader
   alias CubDB.Snapshot
   alias CubDB.Tx
 
-  @enforce_keys [:btree, :compacting, :owner]
+  @enforce_keys [:btree, :compacting, :owner, :db]
   defstruct [
     :btree,
     :compacting,
     :owner,
+    :db,
     recompact: false
   ]
 
@@ -16,6 +25,7 @@ defmodule CubDB.Tx do
            btree: Btree.t(),
            compacting: boolean,
            owner: GenServer.from(),
+           db: GenServer.server(),
            recompact: boolean
          }
 
@@ -32,7 +42,8 @@ defmodule CubDB.Tx do
   It works the same as `CubDB.get/3`, but reads from a transaction instead of
   the live database.
   """
-  def get(%Tx{btree: btree}, key, default \\ nil) do
+  def get(tx = %Tx{btree: btree}, key, default \\ nil) do
+    validate_transaction!(tx)
     Reader.get(btree, key, default)
   end
 
@@ -48,7 +59,8 @@ defmodule CubDB.Tx do
   It works the same as `CubDB.fetch/2`, but reads from a transaction instead of
   the live database.
   """
-  def fetch(%Tx{btree: btree}, key) do
+  def fetch(tx = %Tx{btree: btree}, key) do
+    validate_transaction!(tx)
     Reader.fetch(btree, key)
   end
 
@@ -60,7 +72,8 @@ defmodule CubDB.Tx do
   It works the same as `CubDB.has_key?/2`, but reads from a transaction instead
   of the live database.
   """
-  def has_key?(%Tx{btree: btree}, key) do
+  def has_key?(tx = %Tx{btree: btree}, key) do
+    validate_transaction!(tx)
     Reader.has_key?(btree, key)
   end
 
@@ -73,8 +86,41 @@ defmodule CubDB.Tx do
   It works the same and accepts the same options as `CubDB.select/2`, but reads
   from a transaction instead of the live database.
   """
-  def select(%Tx{btree: btree}, options \\ []) when is_list(options) do
+  def select(%Tx{btree: btree} = tx, options \\ []) when is_list(options) do
+    validate_transaction!(tx)
     Reader.select(btree, options)
+  end
+
+  @spec select_stream(Tx.t(), [CubDB.select_option()]) :: Enumerable.t()
+
+  @doc """
+  Selects a range of entries from the transaction, returning a lazy stream.
+
+  The lazy stream can only be consumed within the transaction scope, or a
+  `RuntimeError` will be raised.
+
+  It works the same and accepts the same options as `CubDB.select_stream/2`, but
+  reads from a transaction instead of the live database.
+  """
+  def select_stream(%Tx{btree: btree, db: db} = tx, options \\ []) when is_list(options) do
+    Stream.resource(
+      fn ->
+        validate_transaction!(tx)
+        stream = Reader.select_stream(btree, options)
+        step = fn val, _acc -> {:suspend, val} end
+        &Enumerable.reduce(stream, &1, step)
+      end,
+      fn next ->
+        case next.({:cont, nil}) do
+          {:done, _} ->
+            {:halt, nil}
+
+          {:suspended, value, next} ->
+            {[value], next}
+        end
+      end,
+      fn _ -> nil end
+    )
   end
 
   @spec refetch(Tx.t(), CubDB.key(), Snapshot.t()) :: :unchanged | {:ok, CubDB.value()} | :error
@@ -152,7 +198,13 @@ defmodule CubDB.Tx do
   """
   def refetch(tx, key, snapshot)
 
-  def refetch(%Tx{btree: btree}, key, %Snapshot{btree: reference_btree}) do
+  def refetch(%Tx{db: db}, _key, %Snapshot{db: other_db}) when db != other_db do
+    raise "Invalid snapshot from another CubDB process"
+  end
+
+  def refetch(tx = %Tx{btree: btree}, key, %Snapshot{btree: reference_btree}) do
+    validate_transaction!(tx)
+
     case Btree.written_since?(btree, key, reference_btree) do
       false ->
         :unchanged
@@ -170,7 +222,8 @@ defmodule CubDB.Tx do
   It works the same as `CubDB.size/1`, but works on a transaction instead of the
   live database.
   """
-  def size(%Tx{btree: btree}) do
+  def size(tx = %Tx{btree: btree}) do
+    validate_transaction!(tx)
     Reader.size(btree)
   end
 
@@ -185,6 +238,7 @@ defmodule CubDB.Tx do
   place, and instead returns a modified transaction.
   """
   def put(tx = %Tx{btree: btree}, key, value) do
+    validate_transaction!(tx)
     %Tx{tx | btree: Btree.insert(btree, key, value)}
   end
 
@@ -201,6 +255,8 @@ defmodule CubDB.Tx do
   place, and instead returns a modified transaction.
   """
   def put_new(tx = %Tx{btree: btree}, key, value) do
+    validate_transaction!(tx)
+
     case Btree.insert_new(btree, key, value) do
       {:error, :exists} = reply ->
         reply
@@ -221,6 +277,8 @@ defmodule CubDB.Tx do
   place, and instead returns a modified transaction.
   """
   def delete(tx = %Tx{btree: btree, compacting: compacting}, key) do
+    validate_transaction!(tx)
+
     if compacting do
       %Tx{tx | btree: Btree.mark_deleted(btree, key)}
     else
@@ -246,6 +304,17 @@ defmodule CubDB.Tx do
   place, and instead returns a modified transaction.
   """
   def clear(tx = %Tx{btree: btree, compacting: compacting}) do
+    validate_transaction!(tx)
     %Tx{tx | btree: Btree.clear(btree), recompact: compacting}
+  end
+
+  defp validate_transaction!(tx = %Tx{db: db}) do
+    case GenServer.call(db, {:validate_transaction, tx}, :infinity) do
+      :ok ->
+        :ok
+
+      :error ->
+        raise "Invalid transaction, likely because it was used outside of its scope"
+    end
   end
 end

--- a/lib/cubdb/transaction.ex
+++ b/lib/cubdb/transaction.ex
@@ -77,21 +77,7 @@ defmodule CubDB.Tx do
     Reader.has_key?(btree, key)
   end
 
-  @spec select(Tx.t(), [CubDB.select_option()]) :: any
-
-  @doc """
-  Selects a range of entries from the transaction, and optionally performs a
-  pipeline of operations on them.
-
-  It works the same and accepts the same options as `CubDB.select/2`, but reads
-  from a transaction instead of the live database.
-  """
-  def select(%Tx{btree: btree} = tx, options \\ []) when is_list(options) do
-    validate_transaction!(tx)
-    Reader.select(btree, options)
-  end
-
-  @spec select_stream(Tx.t(), [CubDB.select_option()]) :: Enumerable.t()
+  @spec select(Tx.t(), [CubDB.select_option()]) :: Enumerable.t()
 
   @doc """
   Selects a range of entries from the transaction, returning a lazy stream.
@@ -99,14 +85,14 @@ defmodule CubDB.Tx do
   The lazy stream can only be consumed within the transaction scope, or a
   `RuntimeError` will be raised.
 
-  It works the same and accepts the same options as `CubDB.select_stream/2`, but
-  reads from a transaction instead of the live database.
+  It works the same and accepts the same options as `CubDB.select/2`, but reads
+  from a transaction instead of the live database.
   """
-  def select_stream(%Tx{btree: btree, db: db} = tx, options \\ []) when is_list(options) do
+  def select(%Tx{btree: btree} = tx, options \\ []) when is_list(options) do
     Stream.resource(
       fn ->
         validate_transaction!(tx)
-        stream = Reader.select_stream(btree, options)
+        stream = Reader.select(btree, options)
         step = fn val, _acc -> {:suspend, val} end
         &Enumerable.reduce(stream, &1, step)
       end,

--- a/mix.exs
+++ b/mix.exs
@@ -86,7 +86,8 @@ defmodule CubDB.Mixfile do
         LICENSE: [title: "License"],
         "README.md": [title: "Overview"],
         "FAQ.md": [],
-        "HOWTO.md": []
+        "HOWTO.md": [],
+        "UPGRADING.md": [title: "Upgrade Guide"]
       ],
       main: "readme",
       logo: "assets/cubdb_logo.png",

--- a/test/cubdb/compactor_test.exs
+++ b/test/cubdb/compactor_test.exs
@@ -39,7 +39,7 @@ defmodule CubDB.CompactorTest do
 
       all_entries = Enum.concat(entries, more_entries) |> Enum.sort()
 
-      assert ^all_entries = CubDB.select(db)
+      assert ^all_entries = CubDB.select(db) |> Enum.to_list()
       assert CubDB.current_db_file(db) == Path.join(tmp_dir, "1.cub")
       refute Store.open?(store)
     end

--- a/test/cubdb/reader_test.exs
+++ b/test/cubdb/reader_test.exs
@@ -46,60 +46,16 @@ defmodule CubDB.Store.ReaderTest do
   end
 
   test "select/2 selects all entries", %{btree: btree, entries: entries} do
-    assert ^entries = Reader.select(btree, [])
+    assert ^entries = Reader.select(btree, []) |> Enum.to_list()
   end
 
   test "select/2 with :min_key and :max_key selects a range of entries", %{btree: btree} do
-    assert [b: 2, c: 3, d: 4] = Reader.select(btree, min_key: :b, max_key: :d)
-  end
-
-  test "select/2 with :filter and :map selects a range of entries and applies the pipe", %{
-    btree: btree
-  } do
-    assert [2, 4, 6] =
-             Reader.select(
-               btree,
-               pipe: [
-                 filter: fn {_, value} -> rem(value, 2) == 0 end,
-                 map: fn {_, value} -> value end
-               ]
-             )
-  end
-
-  test "select/2 with :reduce applies the reduction", %{btree: btree} do
-    assert 28 =
-             Reader.select(
-               btree,
-               pipe: [map: fn {_, value} -> value end],
-               reduce: fn value, sum -> sum + value end
-             )
-
-    assert 28 =
-             Reader.select(
-               btree,
-               reduce: {0, fn {_, value}, sum -> sum + value end}
-             )
+    assert [b: 2, c: 3, d: 4] = Reader.select(btree, min_key: :b, max_key: :d) |> Enum.to_list()
   end
 
   test "select/2 with :reverse selects in inverse order", %{btree: btree, entries: entries} do
     reverse_entries = Enum.reverse(entries)
 
-    assert ^reverse_entries = Reader.select(btree, reverse: true)
-  end
-
-  test "select/2 with :take and :drop takes and drops entries", %{btree: btree} do
-    assert [c: 3, d: 4] = Reader.select(btree, pipe: [take: 4, drop: 2])
-  end
-
-  test "select/2 with :take_while and :drop_while", %{btree: btree} do
-    assert [c: 3, d: 4] =
-             Reader.select(
-               btree,
-               pipe: [take_while: fn {_, v} -> v < 5 end, drop_while: fn {_, v} -> v < 3 end]
-             )
-  end
-
-  test "perform/2 performs :select with invalid :pipe", %{btree: btree} do
-    assert_raise ArgumentError, fn -> Reader.select(btree, pipe: [xxx: 123]) end
+    assert ^reverse_entries = Reader.select(btree, reverse: true) |> Enum.to_list()
   end
 end

--- a/test/cubdb/snapshot_test.exs
+++ b/test/cubdb/snapshot_test.exs
@@ -12,7 +12,9 @@ defmodule CubDB.SnapshotTest do
     {:ok, tmp_dir: tmp_dir}
   end
 
-  test "get, get_multi, fetch, has_key?, size, and select work as expected", %{tmp_dir: tmp_dir} do
+  test "get, get_multi, fetch, has_key?, size, select, and select_stream work as expected", %{
+    tmp_dir: tmp_dir
+  } do
     {:ok, db} = CubDB.start_link(tmp_dir)
     CubDB.put_multi(db, a: 1, c: 3)
 
@@ -31,6 +33,8 @@ defmodule CubDB.SnapshotTest do
     refute CubDB.Snapshot.has_key?(snap, :b)
 
     assert [a: 1, c: 3] = CubDB.Snapshot.select(snap)
+
+    assert [a: 1, c: 3] = CubDB.Snapshot.select_stream(snap) |> Enum.into([])
 
     assert 2 = CubDB.Snapshot.size(snap)
 
@@ -61,6 +65,37 @@ defmodule CubDB.SnapshotTest do
 
     assert result == [a: 1, b: 2, c: 3, d: 4, e: 5]
     assert_receive :clean_up_started, 1000
+
+    snap = CubDB.snapshot(db, 50)
+    :ok = CubDB.compact(db)
+
+    result =
+      CubDB.Snapshot.select_stream(snap)
+      |> Stream.map(fn x ->
+        Process.sleep(20)
+        x
+      end)
+      |> Enum.into([])
+
+    assert result == [a: 1, b: 2, c: 3, d: 4, e: 5]
+    assert_receive :clean_up_started, 1000
+  end
+
+  test "select_stream/2 raises if the stream is consumed when the snapshot is not valid anymore",
+       %{tmp_dir: tmp_dir} do
+    {:ok, db} = CubDB.start_link(tmp_dir)
+    CubDB.put(db, :a, 1)
+
+    stream =
+      CubDB.with_snapshot(db, fn snap ->
+        CubDB.Snapshot.select_stream(snap)
+      end)
+
+    assert_raise RuntimeError,
+                 "Attempt to use CubDB snapshot after it was released or it timed out",
+                 fn ->
+                   Stream.run(stream)
+                 end
   end
 
   describe "back_up/2" do

--- a/test/cubdb/transaction_test.exs
+++ b/test/cubdb/transaction_test.exs
@@ -12,7 +12,9 @@ defmodule CubDB.TransactionTest do
     {:ok, tmp_dir: tmp_dir}
   end
 
-  test "get, get_multi, fetch, has_key?, size, and select work as expected", %{tmp_dir: tmp_dir} do
+  test "get, get_multi, fetch, has_key?, size, select, and select_stream work as expected", %{
+    tmp_dir: tmp_dir
+  } do
     {:ok, db} = CubDB.start_link(tmp_dir)
     CubDB.put_multi(db, a: 1, c: 3)
 
@@ -35,6 +37,8 @@ defmodule CubDB.TransactionTest do
       assert 2 = CubDB.Tx.size(tx)
 
       assert [a: 1, b: 2] = CubDB.Tx.select(tx)
+
+      assert [a: 1, b: 2] = CubDB.Tx.select_stream(tx) |> Enum.into([])
 
       {:cancel, nil}
     end)
@@ -156,5 +160,62 @@ defmodule CubDB.TransactionTest do
     refute CubDB.has_key?(db, :a)
     refute CubDB.has_key?(db, :b)
     assert 0 = CubDB.size(db)
+  end
+
+  test "using the transaction outside of its scope raises an exception", %{tmp_dir: tmp_dir} do
+    {:ok, db} = CubDB.start_link(tmp_dir)
+
+    tx =
+      CubDB.transaction(db, fn tx ->
+        {:cancel, tx}
+      end)
+
+    assert_raise RuntimeError,
+                 "Invalid transaction, likely because it was used outside of its scope",
+                 fn ->
+                   CubDB.Tx.get(tx, :a)
+                 end
+
+    assert_raise RuntimeError,
+                 "Invalid transaction, likely because it was used outside of its scope",
+                 fn ->
+                   CubDB.Tx.fetch(tx, :a)
+                 end
+
+    assert_raise RuntimeError,
+                 "Invalid transaction, likely because it was used outside of its scope",
+                 fn ->
+                   CubDB.Tx.size(tx)
+                 end
+
+    assert_raise RuntimeError,
+                 "Invalid transaction, likely because it was used outside of its scope",
+                 fn ->
+                   CubDB.Tx.select(tx)
+                 end
+
+    assert_raise RuntimeError,
+                 "Invalid transaction, likely because it was used outside of its scope",
+                 fn ->
+                   CubDB.Tx.select_stream(tx) |> Enum.into([])
+                 end
+
+    assert_raise RuntimeError,
+                 "Invalid transaction, likely because it was used outside of its scope",
+                 fn ->
+                   CubDB.Tx.put(tx, :a, 1)
+                 end
+
+    assert_raise RuntimeError,
+                 "Invalid transaction, likely because it was used outside of its scope",
+                 fn ->
+                   CubDB.Tx.delete(tx, :a)
+                 end
+
+    assert_raise RuntimeError,
+                 "Invalid transaction, likely because it was used outside of its scope",
+                 fn ->
+                   CubDB.Tx.clear(tx)
+                 end
   end
 end

--- a/test/cubdb/transaction_test.exs
+++ b/test/cubdb/transaction_test.exs
@@ -12,7 +12,7 @@ defmodule CubDB.TransactionTest do
     {:ok, tmp_dir: tmp_dir}
   end
 
-  test "get, get_multi, fetch, has_key?, size, select, and select_stream work as expected", %{
+  test "get, get_multi, fetch, has_key?, size, select work as expected", %{
     tmp_dir: tmp_dir
   } do
     {:ok, db} = CubDB.start_link(tmp_dir)
@@ -36,14 +36,12 @@ defmodule CubDB.TransactionTest do
 
       assert 2 = CubDB.Tx.size(tx)
 
-      assert [a: 1, b: 2] = CubDB.Tx.select(tx)
-
-      assert [a: 1, b: 2] = CubDB.Tx.select_stream(tx) |> Enum.into([])
+      assert [a: 1, b: 2] = CubDB.Tx.select(tx) |> Enum.into([])
 
       {:cancel, nil}
     end)
 
-    assert [a: 1, c: 3] = CubDB.select(db)
+    assert [a: 1, c: 3] = CubDB.select(db) |> Enum.into([])
   end
 
   test "refetch/3 returns :unchanged if the entry was not written, otherwise fetches it", %{
@@ -191,13 +189,7 @@ defmodule CubDB.TransactionTest do
     assert_raise RuntimeError,
                  "Invalid transaction, likely because it was used outside of its scope",
                  fn ->
-                   CubDB.Tx.select(tx)
-                 end
-
-    assert_raise RuntimeError,
-                 "Invalid transaction, likely because it was used outside of its scope",
-                 fn ->
-                   CubDB.Tx.select_stream(tx) |> Enum.into([])
+                   CubDB.Tx.select(tx) |> Enum.into([])
                  end
 
     assert_raise RuntimeError,


### PR DESCRIPTION
`CubDB.select/2` (and `CubDB.Snapshot.select/2`, `CubDB.Tx.Select`) now return a lazy stream, that can be used with functions in the `Stream` and `Enum` modules.

The `:pipe` and `:reduce` options are not supported anymore, as they are replaced by piping into the equivalent functions in `Stream` and `Enum`.

Data is only read from the database when the stream is iterated.

Example:

```elixir
sum =
  CubDB.select(db, min_key: :a, max_key: :f)
  |> Stream.map(fn {_key, value} -> value end) # map values
  |> Stream.filter(fn n -> is_number(n) and n > 0 end) # only positive numbers
  |> Stream.take(10) # take only the first 10 entries in the range
  |> Enum.sum() # sum the selected values
```