### PR TITLE
Raise better exception on file errors

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -49,8 +49,8 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1
       with:
-        elixir-version: '1.13.4'
-        otp-version: '24.3'
+        elixir-version: '1.14.2'
+        otp-version: '25.2'
 
     - name: Restore dependencies cache
       uses: actions/cache@v2
@@ -77,12 +77,14 @@ jobs:
 
   test:
     name: Test OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # Later Ubuntu versions do not have OTP 22
     strategy:
       matrix:
-        otp: ['22.2', '23.3', '24.3']
-        elixir: ['1.7.4', '1.8.2', '1.9.4', '1.10.4', '1.11.4', '1.12.3', '1.13.4']
+        otp: ['22.3', '23.3', '24.3', '25.2']
+        elixir: ['1.7.4', '1.8.2', '1.9.4', '1.10.4', '1.11.4', '1.12.3', '1.13.4', '1.14.2']
         exclude:
+          - otp: '22.3'
+            elixir: '1.14.2'
           - otp: '23.3'
             elixir: '1.7.4'
           - otp: '23.3'
@@ -99,6 +101,18 @@ jobs:
             elixir: '1.9.4'
           - otp: '24.3'
             elixir: '1.10.4'
+          - otp: '25.2'
+            elixir: '1.7.4'
+          - otp: '25.2'
+            elixir: '1.8.2'
+          - otp: '25.2'
+            elixir: '1.9.4'
+          - otp: '25.2'
+            elixir: '1.10.4'
+          - otp: '25.2'
+            elixir: '1.11.4'
+          - otp: '25.2'
+            elixir: '1.12.3'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir

--- a/lib/cubdb/store/file.ex
+++ b/lib/cubdb/store/file.ex
@@ -150,7 +150,10 @@ defimpl CubDB.Store, for: CubDB.Store.File do
 
   defp raise_if_error({:error, :enospc}), do: raise("No space left on device")
 
-  defp raise_if_error({:error, error}) when is_exception(error), do: raise(error)
+  defp raise_if_error({:error, error})
+       # is_exception is only available from Elixir 1.11
+       when is_map(error) and :erlang.is_map_key(:__exception__, error),
+       do: raise(error)
 
   defp raise_if_error({:error, error}), do: raise("File error: #{inspect(error)}")
 

--- a/lib/cubdb/store/file.ex
+++ b/lib/cubdb/store/file.ex
@@ -150,7 +150,9 @@ defimpl CubDB.Store, for: CubDB.Store.File do
 
   defp raise_if_error({:error, :enospc}), do: raise("No space left on device")
 
-  defp raise_if_error({:error, error}), do: raise(error)
+  defp raise_if_error({:error, error}) when is_exception(error), do: raise(error)
+
+  defp raise_if_error({:error, error}), do: raise("File error: #{inspect(error)}")
 
   defp read_term(file, location) do
     with {:ok, <<length::32>>, len} <- read_blocks(file, location, 4),


### PR DESCRIPTION
Resolves: #65 

When the `:file` modules returns an unexpected error, the `CubDB.Store.File` functions raise an exception, causing the `CubDB` genserver to stop, since the error is generally not recoverable.

The problem was that the code was assuming that the second element of the error tuple was an exception, when most commonly it is an atom. This was masking the actual error with a cryptic `function :foo.exception/1 is undefined (module :foo is not available)` exception (where `:foo` is the atom). The issue is now solved.