### PR TITLE
Apply `hibernate_after` option to all applicable processes

### DIFF
--- a/lib/cubdb/store/file.ex
+++ b/lib/cubdb/store/file.ex
@@ -24,10 +24,10 @@ defmodule CubDB.Store.File do
   @enforce_keys [:pid, :file_path]
   defstruct [:pid, :file_path]
 
-  @spec create(String.t()) :: {:ok, t} | {:error, term}
+  @spec create(String.t(), keyword()) :: {:ok, t} | {:error, term}
 
-  def create(file_path) do
-    with {:ok, pid} <- Agent.start_link(fn -> init(file_path) end) do
+  def create(file_path, options \\ []) do
+    with {:ok, pid} <- Agent.start_link(fn -> init(file_path) end, options) do
       {:ok, %Store.File{pid: pid, file_path: file_path}}
     end
   end


### PR DESCRIPTION
CubDB can be configured with the `hibernate_after` option to reduce memory usage when idle. However, this option is currently only applied to the main `CubDB` process. Other processes started by CubDB can also accumulate memory, and applying `hibernate_after` to them can further minimise memory usage when they are idle.

This PR applies the `hibernate_after` option to all applicable processes started by CubDB:
	1.	`CubDB.Store.File`: This process can hold references to large binaries that have been written to file and may not be garbage collected while idle.
	2.	`CubDB.CleanUp`: Although I have not seen this process holding significant memory, `hibernate_after` has been applied just in case it does, and to maintain consistency with other CubDB processes.
	3.	`Task.Supervisor`: Supervisors do not support the `hibernate_after` option, so this option is not applied to this process.